### PR TITLE
fix: Incorrect Display of Select Options within Popover Component

### DIFF
--- a/app/src/routes/(backstage)/(library)/data-entry/selects/single-selects/+page.vue
+++ b/app/src/routes/(backstage)/(library)/data-entry/selects/single-selects/+page.vue
@@ -4,6 +4,7 @@ import { XBreadcrumb, XCard, XSelect } from '@x/ui';
 
 import WithTable from './WithTable.vue';
 import WithTableInDialog from './WithTableInDialog.vue';
+import WithTableInPopover from './WithTableInPopover.vue';
 
 const flux = reactive({
   select1: '',
@@ -100,6 +101,22 @@ const flux = reactive({
 
       <XCard>
         <WithTableInDialog />
+      </XCard>
+    </section>
+  </section>
+
+  <section class="my-8">
+    <h2 class="text-3xl font-bold my-4 pt-6">With Table</h2>
+
+    <XCard>
+      <WithTable />
+    </XCard>
+
+    <section class="my-4">
+      <h3 class="text-2xl font-semibold my-4 pt-2">In Popover</h3>
+
+      <XCard>
+        <WithTableInPopover />
       </XCard>
     </section>
   </section>

--- a/app/src/routes/(backstage)/(library)/data-entry/selects/single-selects/WithTableInPopover.vue
+++ b/app/src/routes/(backstage)/(library)/data-entry/selects/single-selects/WithTableInPopover.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { reactive } from 'vue';
+import { XPopover, XButton, XSelect, XCard } from '@x/ui';
+const flux = reactive({
+  popoverStatus: false,
+  select: '',
+  select1Options: [
+    { label: 'Angular', value: 'f1' },
+    { label: 'React', value: 'f2' },
+    { label: 'Svelte', value: 'f3' },
+    { label: 'Vue', value: 'f4' },
+    { label: 'Nest', value: 'b1' },
+    { label: 'Express', value: 'b2' },
+    { label: 'Fastify', value: 'b3' },
+    { label: 'Koa', value: 'b4' },
+  ],
+});
+</script>
+
+<template>
+  <XPopover v-model="flux.popoverStatus">
+    <XButton label="Launch" @click="flux.popoverStatus = true" />
+    <template #content>
+      <XCard>
+        <XSelect
+          v-model:value="flux.select"
+          :label="'Example label'"
+          :options="flux.select1Options"
+          use-parent-offset
+        />
+      </XCard>
+    </template>
+  </XPopover>
+</template>

--- a/ui/src/components/select/Select.vue
+++ b/ui/src/components/select/Select.vue
@@ -35,6 +35,7 @@ const props = withDefaults(
     notFoundContent?: string;
     invalid?: boolean | string;
     help?: string;
+    useParentOffset?: boolean;
   }>(),
   {
     label: '',
@@ -49,6 +50,7 @@ const props = withDefaults(
     notFoundContent: '',
     invalid: undefined,
     help: '',
+    useParentOffset: false,
   },
 );
 
@@ -110,17 +112,25 @@ watch(
 
 function resizePanel() {
   const rect = selectInput.value.getBoundingClientRect();
+  const offsetParent = selectInput.value.offsetParent as HTMLElement;
+  const parentRect = offsetParent.getBoundingClientRect();
 
   selectPanel.value.style.width = `${rect.width}px`;
-  selectPanel.value.style.left = `${rect.left}px`;
+  selectPanel.value.style.left = props.useParentOffset
+    ? `${rect.left - parentRect.left}px`
+    : `${rect.left}px`;
 
   const center = window.innerHeight / 2;
 
   if (rect.top > center) {
-    selectPanel.value.style.top = `${rect.top}px`;
+    selectPanel.value.style.top = props.useParentOffset
+      ? `${rect.top - parentRect.top}px`
+      : `${rect.top}px`;
     flux.direction = 'up';
   } else {
-    selectPanel.value.style.top = `${rect.bottom}px`;
+    selectPanel.value.style.top = props.useParentOffset
+      ? `${rect.bottom - parentRect.top}px`
+      : `${rect.bottom}px`;
     flux.direction = 'down';
   }
 }

--- a/ui/src/components/select/__tests__/Select.spec.ts
+++ b/ui/src/components/select/__tests__/Select.spec.ts
@@ -1,0 +1,129 @@
+import {mount} from '@vue/test-utils';
+import Select from '../Select.vue';
+
+import {createLocaler} from 'vue-localer';
+
+const localer = createLocaler({
+  fallbackLocale: 'en-US',
+  messages: {
+    'en-US': {
+      table: {
+        pleaseSelect: 'Please select',
+        notFoundContent: 'No results found'
+      },
+    },
+  },
+});
+describe('Select.vue', () => {
+  it('displays placeholder when no option is selected', () => {
+    const wrapper = mount(Select, {
+      props: {
+        placeholder: 'Select an option',
+        options: [{label: 'Option 1', value: '1'}],
+      },
+      global: {
+        plugins: [localer],
+      },
+    });
+
+    expect(wrapper.text()).toContain('Select an option');
+  });
+
+  it('displays selected option', async () => {
+    const wrapper = mount(Select, {
+      props: {
+        options: [{label: 'Option 1', value: '1'}],
+      },
+      global: {
+        plugins: [localer],
+      },
+    });
+
+    await wrapper.setProps({modelValue: '1'});
+
+    expect(wrapper.text()).toContain('Option 1');
+  });
+
+  it('emits change event when option is selected', async () => {
+    const wrapper = mount(Select, {
+      props: {
+        options: [{label: 'Option 1', value: '1'}],
+      },
+      global: {
+        plugins: [localer],
+      },
+    });
+
+    await wrapper.find('.Select-Item').trigger('click');
+
+    expect(wrapper.emitted()).toHaveProperty('change');
+    expect(wrapper.emitted().change[0]).toEqual(['1', {label: 'Option 1', value: '1'}]);
+  });
+
+  it('filters options based on input', async () => {
+    const wrapper = mount(Select, {
+      props: {
+        options: [
+          {label: 'Option 1', value: '1'},
+          {label: 'Option 2', value: '2'},
+        ],
+        filterable: true,
+      }, global: {
+        plugins: [localer],
+      },
+    });
+
+    await wrapper.find('input').setValue('Option 1');
+
+    expect(wrapper.findAll('.Select-Item')).toHaveLength(1);
+    expect(wrapper.text()).toContain('Option 1');
+  });
+
+  it('displays not found content when no options match filter', async () => {
+    const wrapper = mount(Select, {
+      props: {
+        options: [
+          {label: 'Option 1', value: '1'},
+          {label: 'Option 2', value: '2'},
+        ],
+        filterable: true,
+        notFoundContent: 'No options found',
+      }, global: {
+        plugins: [localer],
+      },
+    });
+
+    await wrapper.find('input').setValue('Option 3');
+
+    expect(wrapper.text()).toContain('No options found');
+  });
+
+  it('does not allow selection when disabled', async () => {
+    const wrapper = mount(Select, {
+      props: {
+        options: [{label: 'Option 1', value: '1'}],
+        disabled: true,
+      }, global: {
+        plugins: [localer],
+      },
+    });
+
+    await wrapper.find('.Select-Input').trigger('click');
+
+    expect(wrapper.emitted()).not.toHaveProperty('change');
+  });
+
+  it('displays placeholder when options list is empty', () => {
+    const wrapper = mount(Select, {
+      props: {
+        placeholder: 'No options available',
+        options: [],
+      },
+      global: {
+        plugins: [localer],
+      },
+    });
+
+    expect(wrapper.text()).toContain('No options available');
+  });
+});


### PR DESCRIPTION
Description
When the Select component is nested within the Popover component, there is a display issue where the options dropdown appears misaligned. This misalignment occurs due to the improper calculation of the top position, failing to account for the offset of the parent element.

<img width="639" alt="Screenshot 2024-03-20 at 08 25 32" src="https://github.com/Shyam-Chen/Vue-Starter/assets/163105757/dcba0f34-d8f0-4feb-90e2-5904dbb5419a">

**Proposed Solution:**
Introduce a new property, let's call it "parentOffset," within the Select component. This property will dynamically calculate the offset of the parent element (e.g., Popover) and adjust the positioning of the options dropdown accordingly. When the Select component is placed within a parent component like Popover, the "parentOffset" property will be utilized to ensure proper alignment.

**Implementation Steps:**

1. Add a new property named "`useParentOffset`" to the `Select` component.
2. Implement logic within the `Select` component to calculate the offset of the parent element (e.g., `Popover`) dynamically.
3. Adjust the positioning of the options dropdown based on the calculated parent offset.
4. Ensure that the "`useParentOffset`" property is utilized only when the Select component is nested within a parent component like Popover.
<img width="1043" alt="Screenshot 2024-03-20 at 08 32 02" src="https://github.com/Shyam-Chen/Vue-Starter/assets/163105757/57ad9edc-fa33-4ca9-90b0-3ccb5c0e5ba7">
<img width="223" alt="Screenshot 2024-03-20 at 08 32 45" src="https://github.com/Shyam-Chen/Vue-Starter/assets/163105757/59fcfd8a-6d62-4811-944b-d78f7d5f04ca">

Closes: https://github.com/Shyam-Chen/Vue-Starter/issues/97